### PR TITLE
feat(mobile): added IconColor property on ZeroNavigationBar

### DIFF
--- a/packages/mobile/lib/components/navigation/zero_navigation_bar.dart
+++ b/packages/mobile/lib/components/navigation/zero_navigation_bar.dart
@@ -79,6 +79,11 @@ class ZeroNavigationBar extends StatelessWidget {
                     return _Segment(
                       icon: active ? item.activeIcon ?? item.icon : item.icon,
                       isActive: active,
+                      iconColor: active
+                          ? (adaptiveStyle.selectedIconColor ??
+                              adaptiveStyle.selectedColor)
+                          : (adaptiveStyle.unselectedIconColor ??
+                              adaptiveStyle.unselectedColor),
                       color: active
                           ? adaptiveStyle.selectedColor
                           : adaptiveStyle.unselectedColor,
@@ -125,6 +130,7 @@ class _Segment extends StatelessWidget {
     this.label,
     this.onTap,
     this.color,
+    this.iconColor,
     required this.indicatorColor,
     required this.indicatorType,
   });
@@ -134,6 +140,7 @@ class _Segment extends StatelessWidget {
   final bool isActive;
   final VoidCallback? onTap;
   final Color? color;
+  final Color? iconColor;
   final Color indicatorColor;
   final ZeroNavigationBarIndicatorType indicatorType;
 
@@ -173,7 +180,7 @@ class _Segment extends StatelessWidget {
                         ),
                         IconTheme(
                           data: IconThemeData(
-                            color: color,
+                            color: iconColor,
                             size: 24,
                           ),
                           child: icon,

--- a/packages/mobile/lib/styles/component/navigation_bar_style.dart
+++ b/packages/mobile/lib/styles/component/navigation_bar_style.dart
@@ -20,6 +20,12 @@ class ZeroNavigationBarStyle with Diagnosticable {
   /// Label color when state is selected/active
   final Color? selectedColor;
 
+  /// Icon color when state is unselected/inactive
+  final Color? unselectedIconColor;
+
+  /// Icon color when state is selected/active
+  final Color? selectedIconColor;
+
   /// Type indicator on active
   final ZeroNavigationBarIndicatorType? indicatorType;
 
@@ -29,6 +35,8 @@ class ZeroNavigationBarStyle with Diagnosticable {
     this.indicatorColor,
     this.unselectedColor,
     this.selectedColor,
+    this.unselectedIconColor,
+    this.selectedIconColor,
     this.indicatorType,
   });
 
@@ -38,11 +46,15 @@ class ZeroNavigationBarStyle with Diagnosticable {
     Color? indicatorColor,
     Color? unselectedColor,
     Color? selectedColor,
+    Color? unselectedIconColor,
+    Color? selectedIconColor,
   }) =>
       ZeroNavigationBarStyle(
         backgroundColor: backgroundColor ?? Colors.white,
         unselectedColor: unselectedColor ?? Colors.black,
         selectedColor: selectedColor ?? Colors.black,
+        unselectedIconColor: unselectedIconColor ?? unselectedColor ?? Colors.black,
+        selectedIconColor: selectedIconColor ?? selectedColor ?? Colors.black,
         indicatorColor:
             indicatorColor ?? ZeroColors.primary.toAccentColor().lighter,
         indicatorType: ZeroNavigationBarIndicatorType.oval,
@@ -58,6 +70,8 @@ class ZeroNavigationBarStyle with Diagnosticable {
     Color? indicatorColor,
     Color? unselectedColor,
     Color? selectedColor,
+    Color? unselectedIconColor,
+    Color? selectedIconColor,
     double? height,
     ZeroNavigationBarIndicatorType? indicatorType,
   }) {
@@ -66,6 +80,8 @@ class ZeroNavigationBarStyle with Diagnosticable {
       indicatorColor: indicatorColor ?? this.indicatorColor,
       unselectedColor: unselectedColor ?? this.unselectedColor,
       selectedColor: selectedColor ?? this.selectedColor,
+      unselectedIconColor: unselectedIconColor ?? this.unselectedIconColor,
+      selectedIconColor: selectedIconColor ?? this.selectedIconColor,
       height: height ?? this.height,
       indicatorType: indicatorType ?? this.indicatorType,
     );
@@ -79,6 +95,8 @@ class ZeroNavigationBarStyle with Diagnosticable {
       indicatorColor: other.indicatorColor,
       unselectedColor: other.unselectedColor,
       selectedColor: other.selectedColor,
+      unselectedIconColor: other.unselectedIconColor,
+      selectedIconColor: other.selectedIconColor,
       height: other.height,
       indicatorType: other.indicatorType,
     );
@@ -91,6 +109,10 @@ class ZeroNavigationBarStyle with Diagnosticable {
       indicatorColor: Color.lerp(a?.indicatorColor, b?.indicatorColor, t),
       unselectedColor: Color.lerp(a?.unselectedColor, b?.unselectedColor, t),
       selectedColor: Color.lerp(a?.selectedColor, b?.selectedColor, t),
+      unselectedIconColor:
+          Color.lerp(a?.unselectedIconColor, b?.unselectedIconColor, t),
+      selectedIconColor:
+          Color.lerp(a?.selectedIconColor, b?.selectedIconColor, t),
       height: t < 0.5 ? a?.height : b?.height,
       indicatorType: t < 0.5 ? a?.indicatorType : b?.indicatorType,
     );
@@ -111,6 +133,8 @@ class ZeroNavigationBarStyle with Diagnosticable {
       ..add(ColorProperty('backgroundColor', backgroundColor))
       ..add(ColorProperty('indicatorColor', indicatorColor))
       ..add(ColorProperty('unselectedColor', unselectedColor))
+      ..add(ColorProperty('selectedIconColor', selectedIconColor))
+      ..add(ColorProperty('unselectedIconColor', unselectedIconColor))
       ..add(ColorProperty('selectedColor', selectedColor))
       ..add(DoubleProperty('height', height));
   }

--- a/packages/mobile/lib/styles/component/navigation_bar_style.dart
+++ b/packages/mobile/lib/styles/component/navigation_bar_style.dart
@@ -80,8 +80,8 @@ class ZeroNavigationBarStyle with Diagnosticable {
       indicatorColor: indicatorColor ?? this.indicatorColor,
       unselectedColor: unselectedColor ?? this.unselectedColor,
       selectedColor: selectedColor ?? this.selectedColor,
-      unselectedIconColor: unselectedIconColor ?? this.unselectedIconColor,
-      selectedIconColor: selectedIconColor ?? this.selectedIconColor,
+      unselectedIconColor: unselectedIconColor ?? unselectedColor ?? this.unselectedIconColor,
+      selectedIconColor: selectedIconColor ?? selectedColor ?? this.selectedIconColor,
       height: height ?? this.height,
       indicatorType: indicatorType ?? this.indicatorType,
     );

--- a/packages/mobile/widgetbook/lib/widgetbook_component/navigation_bar.dart
+++ b/packages/mobile/widgetbook/lib/widgetbook_component/navigation_bar.dart
@@ -37,6 +37,10 @@ class __NavigationBarWidgetState extends State<_NavigationBarWidget> {
               .options(label: 'Selected Color', options: _defaultColorOptions),
           unselectedColor: context.knobs.options(
               label: 'Unselected Color', options: _defaultColorOptions),
+          selectedIconColor: context.knobs
+              .options(label: 'Selected Icon Color', options: _defaultColorOptions),
+          unselectedIconColor: context.knobs.options(
+              label: 'Unselected Icon Color', options: _defaultColorOptions),
           indicatorColor: context.knobs
               .options(label: 'Indicator Color', options: colorOptions)
               .withOpacity(0.3),
@@ -98,7 +102,8 @@ List<Option<ZeroNavigationBarIndicatorType>> _indicatorOptions = [
   const Option(label: 'Circle', value: ZeroNavigationBarIndicatorType.circle),
 ];
 
-List<Option<Color>> _defaultColorOptions = [
+List<Option<Color?>> _defaultColorOptions = [
+  const Option(label: 'None', value: null),
   const Option(label: 'Black', value: Colors.black),
   ...colorOptions,
 ];


### PR DESCRIPTION
Added custom `selectedIconColor` and `unselectedIconColor` to ZeroNavigationBarStyle.

If it happen to be `null`, default value comes from `selectedColor` and `unselectedColor` respectively.