### PR TITLE
Fix/bottom sheet color and appbar title spacing

### DIFF
--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.1-alpha.9
+
+* fix: set ZeroButtomSheet surfaceTintColor equal to backgroundColor value
+* feat: add titleSpacing in ZeroAppBarStyle
+
 ## 0.0.1-alpha.8
 
 * fix: Fix ZeroTheme to apply child widget

--- a/packages/mobile/lib/components/navigation/zero_app_bar.dart
+++ b/packages/mobile/lib/components/navigation/zero_app_bar.dart
@@ -143,9 +143,7 @@ class ZeroAppBar extends StatelessWidget implements PreferredSizeWidget {
 
                                 // Build spacing based on conditions
                                 if (isNoLeading)
-                                  SizedBox(
-                                    width: adaptiveStyle.titleSpacing ?? 16,
-                                  )
+                                  const SizedBox(width: 16)
                                 else if (adaptiveStyle.centerTitle == true)
                                   const SizedBox.shrink()
                                 else

--- a/packages/mobile/lib/components/navigation/zero_app_bar.dart
+++ b/packages/mobile/lib/components/navigation/zero_app_bar.dart
@@ -143,11 +143,15 @@ class ZeroAppBar extends StatelessWidget implements PreferredSizeWidget {
 
                                 // Build spacing based on conditions
                                 if (isNoLeading)
-                                  const SizedBox(width: 16)
+                                  SizedBox(
+                                    width: adaptiveStyle.titleSpacing ?? 16,
+                                  )
                                 else if (adaptiveStyle.centerTitle == true)
                                   const SizedBox.shrink()
                                 else
-                                  const SizedBox(width: 32),
+                                  SizedBox(
+                                    width: adaptiveStyle.titleSpacing ?? 32,
+                                  ),
 
                                 // Build title small size
                                 Expanded(

--- a/packages/mobile/lib/styles/component/app_bar_style.dart
+++ b/packages/mobile/lib/styles/component/app_bar_style.dart
@@ -27,6 +27,9 @@ class ZeroAppBarStyle with Diagnosticable {
   /// A list of shadows cast by this box behind the app bar.
   final List<BoxShadow>? shadows;
 
+  /// spacing around title content on the horizontal axis
+  final double? titleSpacing;
+
   const ZeroAppBarStyle({
     this.backgroundColor,
     this.foregroundColor,
@@ -35,6 +38,7 @@ class ZeroAppBarStyle with Diagnosticable {
     this.centerTitle,
     this.statusBarBrightness,
     this.shadows,
+    this.titleSpacing,
   });
 
   /// A default value style of [ZeroAppBarStyle]
@@ -43,12 +47,14 @@ class ZeroAppBarStyle with Diagnosticable {
     Color? foregroundColor,
     TextStyle? titleStyle,
     Brightness? statusBarBrightness,
+    double? titleSpacing,
   }) =>
       ZeroAppBarStyle(
         backgroundColor: backgroundColor ?? ZeroColors.white,
         foregroundColor: foregroundColor ?? ZeroColors.black,
         titleStyle: titleStyle,
         statusBarBrightness: statusBarBrightness ?? Brightness.light,
+        titleSpacing: titleSpacing,
       );
 
   /// If the caller passes in a value for a parameter, use that value, otherwise use the value from this
@@ -64,6 +70,7 @@ class ZeroAppBarStyle with Diagnosticable {
     bool? centerTitle,
     Brightness? statusBarBrightness,
     List<BoxShadow>? shadows,
+    double? titleSpacing,
   }) {
     return ZeroAppBarStyle(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -73,6 +80,7 @@ class ZeroAppBarStyle with Diagnosticable {
       centerTitle: centerTitle ?? this.centerTitle,
       statusBarBrightness: statusBarBrightness ?? this.statusBarBrightness,
       shadows: shadows ?? this.shadows,
+      titleSpacing: titleSpacing ?? this.titleSpacing,
     );
   }
 
@@ -87,6 +95,7 @@ class ZeroAppBarStyle with Diagnosticable {
       centerTitle: other.centerTitle,
       statusBarBrightness: other.statusBarBrightness,
       shadows: other.shadows,
+      titleSpacing: other.titleSpacing,
     );
   }
 
@@ -101,6 +110,7 @@ class ZeroAppBarStyle with Diagnosticable {
       statusBarBrightness:
           t < 0.5 ? a?.statusBarBrightness : b?.statusBarBrightness,
       shadows: t < 0.5 ? a?.shadows : b?.shadows,
+      titleSpacing: t < 0.5 ? a?.titleSpacing : b?.titleSpacing,
     );
   }
 
@@ -114,6 +124,7 @@ class ZeroAppBarStyle with Diagnosticable {
           statusBarColor: Colors.transparent,
           statusBarBrightness: statusBarBrightness,
         ),
+        titleSpacing: titleSpacing,
       );
 
   @override
@@ -128,6 +139,7 @@ class ZeroAppBarStyle with Diagnosticable {
       ..add(DiagnosticsProperty<TextStyle>('titleStyle', titleStyle))
       ..add(DiagnosticsProperty<Brightness>(
           'statusBarBrightness', statusBarBrightness))
-      ..add(DiagnosticsProperty<List<BoxShadow>>('shadows', shadows));
+      ..add(DiagnosticsProperty<List<BoxShadow>>('shadows', shadows))
+      ..add(DiagnosticsProperty<double>('titleSpacing', titleSpacing));
   }
 }

--- a/packages/mobile/lib/styles/component/bottom_sheet_style.dart
+++ b/packages/mobile/lib/styles/component/bottom_sheet_style.dart
@@ -102,6 +102,7 @@ class ZeroBottomSheetStyle with Diagnosticable {
         modalBarrierColor: barierColor,
         elevation: elevation,
         surfaceTintColor: backgroundColor,
+        modalBackgroundColor: backgroundColor,
       );
 
   @override

--- a/packages/mobile/lib/styles/component/bottom_sheet_style.dart
+++ b/packages/mobile/lib/styles/component/bottom_sheet_style.dart
@@ -101,6 +101,7 @@ class ZeroBottomSheetStyle with Diagnosticable {
         ),
         modalBarrierColor: barierColor,
         elevation: elevation,
+        surfaceTintColor: backgroundColor,
       );
 
   @override

--- a/packages/mobile/pubspec.yaml
+++ b/packages/mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zog_ui
 description: A collection of ready-to-use ZOG design system UI components providing both implementation simplicity and customizability 
-version: 0.0.1-alpha.8
+version: 0.0.1-alpha.9
 homepage: https://zero-ui-mobile.web.app/
 repository: https://github.com/zero-one-group/zog-ui/tree/main/packages/mobile
 issue_tracker: https://github.com/zero-one-group/zog-ui/issues


### PR DESCRIPTION
Changes : 
- set ZeroButtomSheet surfaceTintColor equal to backgroundColor value
- feat: add titleSpacing in ZeroAppBarStyle