### PR TITLE
Fix/app bar title spacing and adjust tab label padding style

### DIFF
--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.1-alpha.12
+
+* fix: `AppBar` titleSpacing not working
+* fix: `ZeroTabBar` when scrollable, the position is not center
+* style: `ZeroTabBar` add property style `labelPadding`
+
 ## 0.0.1-alpha.11
 
 * hotfix: ZeroApp.router() bug when no `builder` provided

--- a/packages/mobile/lib/components/navigation/zero_app_bar.dart
+++ b/packages/mobile/lib/components/navigation/zero_app_bar.dart
@@ -97,7 +97,11 @@ class ZeroAppBar extends StatelessWidget implements PreferredSizeWidget {
       statusBarBrightness: adaptiveStyle.statusBarBrightness,
     );
 
-    final isNoLeading = !automaticallyImplyLeading && leading == null;
+    final isNoLeading = !_checkHasLeading(
+          context: context,
+          automaticallyImplyLeading: automaticallyImplyLeading,
+        ) &&
+        leading == null;
 
     return Semantics(
       container: true,
@@ -143,7 +147,9 @@ class ZeroAppBar extends StatelessWidget implements PreferredSizeWidget {
 
                                 // Build spacing based on conditions
                                 if (isNoLeading)
-                                  const SizedBox(width: 16)
+                                  SizedBox(
+                                    width: adaptiveStyle.titleSpacing ?? 16,
+                                  )
                                 else if (adaptiveStyle.centerTitle == true)
                                   const SizedBox.shrink()
                                 else
@@ -236,6 +242,22 @@ class _Title extends StatelessWidget {
   }
 }
 
+bool _checkHasLeading({
+  required BuildContext context,
+  required bool automaticallyImplyLeading,
+}) {
+  if (automaticallyImplyLeading == false) {
+    return false;
+  }
+
+  final scaffold = Scaffold.maybeOf(context);
+  final parentRoute = ModalRoute.of(context);
+  final hasDrawer = scaffold?.hasDrawer ?? false;
+  final canPop = parentRoute?.canPop ?? false;
+
+  return hasDrawer || canPop;
+}
+
 /// A widget for building leading of [ZeroAppBar]
 class _Leading extends StatelessWidget {
   const _Leading({
@@ -251,37 +273,42 @@ class _Leading extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (automaticallyImplyLeading == false || leading != null) {
-      return leading ?? const SizedBox.shrink();
-    }
+    final hasLeading = _checkHasLeading(
+      context: context,
+      automaticallyImplyLeading: automaticallyImplyLeading,
+    );
 
-    final scaffold = Scaffold.maybeOf(context);
-    final parentRoute = ModalRoute.of(context);
-    final hasDrawer = scaffold?.hasDrawer ?? false;
-    final canPop = parentRoute?.canPop ?? false;
-    final localization = MaterialLocalizations.of(context);
+    if (leading != null) return leading!;
 
-    // Build leading when have drawer in scaffold
-    if (hasDrawer) {
-      return IconButton(
-        // Action to open drawer
-        onPressed: () {
-          Scaffold.of(context).openDrawer();
-        },
-        icon: const Icon(ZeroIcons.menu),
-        tooltip: localization.openAppDrawerTooltip,
-      );
-    }
+    if (hasLeading) {
+      final scaffold = Scaffold.maybeOf(context);
+      final parentRoute = ModalRoute.of(context);
+      final hasDrawer = scaffold?.hasDrawer ?? false;
+      final canPop = parentRoute?.canPop ?? false;
+      final localization = MaterialLocalizations.of(context);
 
-    // Build leading back button
-    if (canPop) {
-      return IconButton(
-        onPressed: () {
-          Navigator.of(context).pop();
-        },
-        icon: const Icon(ZeroIcons.arrowLeft),
-        tooltip: localization.backButtonTooltip,
-      );
+      // Build leading when have drawer in scaffold
+      if (hasDrawer) {
+        return IconButton(
+          // Action to open drawer
+          onPressed: () {
+            Scaffold.of(context).openDrawer();
+          },
+          icon: const Icon(ZeroIcons.menu),
+          tooltip: localization.openAppDrawerTooltip,
+        );
+      }
+
+      // Build leading back button
+      if (canPop) {
+        return IconButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          icon: const Icon(ZeroIcons.arrowLeft),
+          tooltip: localization.backButtonTooltip,
+        );
+      }
     }
 
     return const SizedBox.shrink();

--- a/packages/mobile/lib/components/navigation/zero_tab_bar.dart
+++ b/packages/mobile/lib/components/navigation/zero_tab_bar.dart
@@ -39,29 +39,34 @@ class ZeroTabBar extends StatelessWidget {
 
     return Ink(
       color: adaptiveStyle.backgroundColor,
-      child: ZeroTheme(
-        data: theme.copyWith(
-          tabBarStyle: adaptiveStyle,
-        ),
-        child: TabBar(
-          controller: controller,
-          dividerColor: Colors.transparent,
-          unselectedLabelColor: adaptiveStyle.inactiveColor,
-          labelColor: adaptiveStyle.activeColor,
-          indicator: UnderlineTabIndicator(
-            borderRadius: const BorderRadius.only(
-              topLeft: Radius.circular(3.0),
-              topRight: Radius.circular(3.0),
-            ),
-            borderSide: BorderSide(
-              color: adaptiveStyle.indicatorColor ?? theme.primaryColor,
-              width: 2,
-            ),
+      child: Container(
+        width: double.infinity,
+        alignment: Alignment.center,
+        child: ZeroTheme(
+          data: theme.copyWith(
+            tabBarStyle: adaptiveStyle,
           ),
-          isScrollable: style?.isScrollable ?? false,
-          onTap: onTap,
-          physics: physics ?? const BouncingScrollPhysics(),
-          tabs: tabs,
+          child: TabBar(
+            controller: controller,
+            dividerColor: Colors.transparent,
+            unselectedLabelColor: adaptiveStyle.inactiveColor,
+            labelColor: adaptiveStyle.activeColor,
+            labelPadding: style?.labelPadding,
+            indicator: UnderlineTabIndicator(
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(3.0),
+                topRight: Radius.circular(3.0),
+              ),
+              borderSide: BorderSide(
+                color: adaptiveStyle.indicatorColor ?? theme.primaryColor,
+                width: 2,
+              ),
+            ),
+            isScrollable: style?.isScrollable ?? false,
+            onTap: onTap,
+            physics: physics ?? const BouncingScrollPhysics(),
+            tabs: tabs,
+          ),
         ),
       ),
     );

--- a/packages/mobile/lib/styles/component/navigation_bar_style.dart
+++ b/packages/mobile/lib/styles/component/navigation_bar_style.dart
@@ -53,7 +53,8 @@ class ZeroNavigationBarStyle with Diagnosticable {
         backgroundColor: backgroundColor ?? Colors.white,
         unselectedColor: unselectedColor ?? Colors.black,
         selectedColor: selectedColor ?? Colors.black,
-        unselectedIconColor: unselectedIconColor ?? unselectedColor ?? Colors.black,
+        unselectedIconColor:
+            unselectedIconColor ?? unselectedColor ?? Colors.black,
         selectedIconColor: selectedIconColor ?? selectedColor ?? Colors.black,
         indicatorColor:
             indicatorColor ?? ZeroColors.primary.toAccentColor().lighter,
@@ -80,8 +81,10 @@ class ZeroNavigationBarStyle with Diagnosticable {
       indicatorColor: indicatorColor ?? this.indicatorColor,
       unselectedColor: unselectedColor ?? this.unselectedColor,
       selectedColor: selectedColor ?? this.selectedColor,
-      unselectedIconColor: unselectedIconColor ?? unselectedColor ?? this.unselectedIconColor,
-      selectedIconColor: selectedIconColor ?? selectedColor ?? this.selectedIconColor,
+      unselectedIconColor:
+          unselectedIconColor ?? unselectedColor ?? this.unselectedIconColor,
+      selectedIconColor:
+          selectedIconColor ?? selectedColor ?? this.selectedIconColor,
       height: height ?? this.height,
       indicatorType: indicatorType ?? this.indicatorType,
     );

--- a/packages/mobile/lib/styles/component/tab_bar_style.dart
+++ b/packages/mobile/lib/styles/component/tab_bar_style.dart
@@ -22,6 +22,9 @@ class ZeroTabBarStyle with Diagnosticable {
   /// Padding item of [ZeroTab]
   final EdgeInsetsGeometry? padding;
 
+  /// The padding added to each of the tab labels.
+  final EdgeInsetsGeometry? labelPadding;
+
   /// Default icon size
   final double? iconSize;
 
@@ -39,6 +42,7 @@ class ZeroTabBarStyle with Diagnosticable {
     this.inactiveColor,
     this.indicatorColor,
     this.padding,
+    this.labelPadding,
     this.iconSize,
     this.labelStyle,
     this.isScrollable = false,
@@ -75,6 +79,7 @@ class ZeroTabBarStyle with Diagnosticable {
     Color? inactiveColor,
     Color? indicatorColor,
     EdgeInsetsGeometry? padding,
+    EdgeInsetsGeometry? labelPadding,
     double? iconSize,
     TextStyle? labelStyle,
     bool? isScrollable,
@@ -85,6 +90,7 @@ class ZeroTabBarStyle with Diagnosticable {
       inactiveColor: inactiveColor ?? this.inactiveColor,
       indicatorColor: indicatorColor ?? this.indicatorColor,
       padding: padding ?? this.padding,
+      labelPadding: labelPadding ?? this.labelPadding,
       iconSize: iconSize ?? this.iconSize,
       labelStyle: labelStyle ?? this.labelStyle,
       isScrollable: isScrollable ?? this.isScrollable,
@@ -100,6 +106,7 @@ class ZeroTabBarStyle with Diagnosticable {
       inactiveColor: other.inactiveColor,
       indicatorColor: other.indicatorColor,
       padding: other.padding,
+      labelPadding: other.labelPadding,
       iconSize: other.iconSize,
       labelStyle: labelStyle?.merge(other.labelStyle) ?? other.labelStyle,
       isScrollable: other.isScrollable,
@@ -114,6 +121,8 @@ class ZeroTabBarStyle with Diagnosticable {
       inactiveColor: Color.lerp(a?.inactiveColor, b?.inactiveColor, t),
       indicatorColor: Color.lerp(a?.indicatorColor, b?.indicatorColor, t),
       padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
+      labelPadding:
+          EdgeInsetsGeometry.lerp(a?.labelPadding, b?.labelPadding, t),
       iconSize: t < 0.5 ? a?.iconSize : b?.iconSize,
       labelStyle: TextStyle.lerp(a?.labelStyle, b?.labelStyle, t),
       isScrollable: (t < 0.5 ? a?.isScrollable : b?.isScrollable) ?? false,
@@ -127,6 +136,8 @@ class ZeroTabBarStyle with Diagnosticable {
         labelColor: activeColor,
         unselectedLabelColor: inactiveColor,
         labelStyle: labelStyle,
+        unselectedLabelStyle: labelStyle?.copyWith(color: inactiveColor),
+        labelPadding: labelPadding,
       );
 
   @override
@@ -138,6 +149,11 @@ class ZeroTabBarStyle with Diagnosticable {
       ..add(ColorProperty('activeColor', activeColor))
       ..add(ColorProperty('inactiveColor', inactiveColor))
       ..add(ColorProperty('indicatorColor', indicatorColor))
-      ..add(DoubleProperty('iconSize', iconSize));
+      ..add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding))
+      ..add(
+          DiagnosticsProperty<EdgeInsetsGeometry>('labelPadding', labelPadding))
+      ..add(DoubleProperty('iconSize', iconSize))
+      ..add(DiagnosticsProperty<TextStyle>('labelStyle', labelStyle))
+      ..add(DiagnosticsProperty<bool>('isScrollable', isScrollable));
   }
 }

--- a/packages/mobile/pubspec.yaml
+++ b/packages/mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zog_ui
 description: A collection of ready-to-use ZOG design system UI components providing both implementation simplicity and customizability 
-version: 0.0.1-alpha.11
+version: 0.0.1-alpha.12
 homepage: https://zero-ui-mobile.web.app/
 repository: https://github.com/zero-one-group/zog-ui/tree/main/packages/mobile
 issue_tracker: https://github.com/zero-one-group/zog-ui/issues


### PR DESCRIPTION
- [x] fix: `AppBar` titleSpacing not working
- [x] fix: `ZeroTabBar` when scrollable, the position is not center
- [x] style: `ZeroTabBar` add property style `labelPadding`