### PR TITLE
Pass the text editing controller to the custom dropdown

### DIFF
--- a/packages/mobile/lib/components/dropdown_menu/zero_dropdown_menu.dart
+++ b/packages/mobile/lib/components/dropdown_menu/zero_dropdown_menu.dart
@@ -159,6 +159,7 @@ class ZeroDropdownMenu<T> extends StatelessWidget {
       menuHeight: menuHeight,
       enableFilter: enableFilter,
       onSelected: onSelected,
+      controller: controller,
       dropdownMenuEntries: entries ??
           items!.map((item) {
             return ZeroDropdownMenuEntry<T>(


### PR DESCRIPTION
Custom TextEditing controllers do not work because they are not passed successfully